### PR TITLE
fix: Ensure text container is visible above Three.js canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,11 @@
     <title>LOGO Homage 1</title> 
     <style>
         body { margin: 0; overflow: hidden; background-color: #111; color: #fff; font-family: 'Inter', sans-serif; }
-        canvas { display: block; }
+        canvas {
+            display: block;
+            position: relative;
+            z-index: 1;
+        }
         #info {
             position: absolute;
             top: 10px;
@@ -77,9 +81,12 @@
 
         // --- DISPLAY RANDOM TEXT LOGIC ---
         function displayRandomText() {
+            console.log('displayRandomText called');
             const textContainer = document.getElementById('text-container');
+            console.log('textContainer:', textContainer);
             if (textContainer) {
                 const randomIndex = Math.floor(Math.random() * textPool.length);
+                console.log('Selected text:', textPool[randomIndex]);
                 textContainer.textContent = textPool[randomIndex];
             }
         }
@@ -99,13 +106,6 @@
             renderer.setSize(window.innerWidth, window.innerHeight);
             document.body.appendChild(renderer.domElement);
             
-            // Lighting
-            const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
-            scene.add(ambientLight);
-            const pointLight = new THREE.PointLight(0xffffff, 0.8);
-            pointLight.position.set(5, 10, 15);
-            scene.add(pointLight);
-
             // Lighting
             const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
             scene.add(ambientLight);


### PR DESCRIPTION
You reported a black screen with no text displayed. This was likely due to the Three.js canvas element rendering on top of the text container div.

This commit addresses the issue by:
- Setting `position: relative` and `z-index: 1` on the `canvas` element in CSS. This ensures it is rendered below other positioned elements with a higher z-index, such as the `#text-container` (z-index: 200) and `#info` (z-index: 100).
- Removing duplicate lighting code in the Three.js `init` function as a minor cleanup.
- Adding console logs to `displayRandomText` for easier debugging (these do not affect functionality).

With these changes, the text from `textPool` should now be correctly displayed, centered, and visible on the screen.